### PR TITLE
モジュールにして、top level awaitが使えるように

### DIFF
--- a/fizzbuzz.js
+++ b/fizzbuzz.js
@@ -1,19 +1,17 @@
 // sleep関数はコピペ
 // Promiseを指定時間後にsetTimeoutでresolveするらしい
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = ms => new Promise((resolve) => setTimeout(resolve, ms));
 
 
-(async function () {
-    for (let i = 1; i < 21; i++) {
-        if (i % 15 === 0) {
-            console.log("FizzBuzz")
-        } else if (i % 3 === 0) {
-            console.log("Fizz")
-        } else if (i % 5 === 0) {
-            console.log("Buzz")
-        } else {
-            console.log(i.toString())
-        }
-        await sleep(300)
+for (let i = 1; i <= 30; i++) {
+    if (i % 15 === 0) {
+        console.log("FizzBuzz")
+    } else if (i % 3 === 0) {
+        console.log("Fizz")
+    } else if (i % 5 === 0) {
+        console.log("Buzz")
+    } else {
+        console.log(i)
     }
-}())
+    await sleep(300)
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "ジャヴァスクリプトを学ぶ会",
   "main": "helloworld.js",
+  "type":"module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
typeがmoduleの場合、import/exportが使えたり、トップレベル(関数内部ではない、一番外側)でawaitをそのまま使えたりして便利なので、こうしてみました。